### PR TITLE
Fixed bug in EW deployments in TF.

### DIFF
--- a/.github/workflows/workers-testing-deployment.yaml
+++ b/.github/workflows/workers-testing-deployment.yaml
@@ -108,6 +108,7 @@ jobs:
       TF_VAR_contract_id: ${{ secrets.CONTRACT_ID }}
       TF_VAR_deployment_name: ${{needs.deployment_name_builder.outputs.deployment_name}}
       DEPLOYMENT_URL: ${{ needs.deployment_name_builder.outputs.deployment_url }}
+      DEPLOYMENT_NAME: ${{ needs.deployment_name_builder.outputs.deployment_name }}
       AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_SECRET_KEY }}
       AKAMAI_ACCOUNT_KEY: ${{ secrets.AKAMAI_ACCOUNT_KEY }}
@@ -120,6 +121,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Short GitHub SHA and Save in Environment Variable
+        run: 	|
+          git config --global --add safe.directory /__w/akamai-starterkit/akamai-starterkit 
+          echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        
       # NOTE you must define EDGERC in your secrets.
       # See here for setting up API credentials: https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials
       - name: Write secret to file
@@ -154,6 +160,12 @@ jobs:
             tofu workspace new "$TF_VAR_deployment_name"
           fi
         working-directory: terraform  
+
+      - run: npm ci
+        working-directory: js
+
+      - run: npm run build
+        working-directory: js
 
       # This is an annoying work around.  Repetitive calls to TF will expect that the bundle/tar exist. Without this `tofu apply` will fail on repetitive builds.       
       - name: Prepare edge worker bundle
@@ -193,8 +205,6 @@ jobs:
               sleep 60
             fi
           done
-      - run: npm ci
-        working-directory: js
 
       - name: Test
         run: npm test

--- a/js/build-scripts/ew-bundle-versioner.js
+++ b/js/build-scripts/ew-bundle-versioner.js
@@ -1,0 +1,31 @@
+const fs = require('fs').promises;
+
+async function updateEdgeworkerVersion() {
+  const deploymentName = process.env.DEPLOYMENT_NAME;
+  const commitHash = process.env.COMMIT_HASH;
+
+  if (!deploymentName || !commitHash) {
+    console.error(`DEPLOYMENT_NAME (${deploymentName}) and COMMIT_HASH (${commitHash}) environment variables are required`);
+    process.exit(1);
+  }
+
+  try {
+    // Step 2: Read the bundle.json file
+    const filePath = '../edge-worker/bundle.json';
+    const data = await fs.readFile(filePath, 'utf8');
+    
+    // Step 3: Parse the JSON
+    const json = JSON.parse(data);
+    
+    // Step 4: Update the edgeworker-version value
+    json['edgeworker-version'] = `${deploymentName}-${commitHash}`;
+    
+    // Step 5: Write the updated JSON back to the file
+    await fs.writeFile(filePath, JSON.stringify(json, null, 2), 'utf8');
+    console.log('Updated edgeworker-version successfully.');
+  } catch (error) {
+    console.error('Failed to update edgeworker-version:', error);
+  }
+}
+
+updateEdgeworkerVersion();

--- a/js/build-scripts/hello-world-injector.js
+++ b/js/build-scripts/hello-world-injector.js
@@ -1,0 +1,31 @@
+const fs = require('fs').promises;
+
+async function helloWorldInjector() {
+  const deploymentName = process.env.DEPLOYMENT_NAME;
+  const commitHash = process.env.COMMIT_HASH; // This is read but not used in this script, based on your instructions.
+
+  if (!deploymentName) {
+    console.error('DEPLOYMENT_NAME environment variable is required');
+    process.exit(1);
+  }
+
+  try {
+    // Step 2: Read the main.js file
+    const filePath = '../edge-worker/main.js';
+    let fileContent = await fs.readFile(filePath, 'utf8');
+    
+    // Step 3: Update the <h1> content
+    fileContent = fileContent.replace(
+      /<h1>Hello World From Akamai EdgeWorkers<\/h1>/,
+      `<h1>Hello World From Akamai EdgeWorkers:</h1><h2>Deployment: ${deploymentName}</h2>`
+    );
+    
+    // Step 4: Write the updated content back to main.js
+    await fs.writeFile(filePath, fileContent, 'utf8');
+    console.log('Updated <h1> content successfully.');
+  } catch (error) {
+    console.error('Failed to update <h1> content:', error);
+  }
+}
+
+helloWorldInjector();

--- a/js/hello-world.test.ts
+++ b/js/hello-world.test.ts
@@ -21,24 +21,17 @@ describe('Deployment URL Test', () => {
     await browser.close();
   });
 
-  it('should contain the text "Hello"', async () => {
+  it('should contain the correct <h1> and <h2> content', async () => {
+    const deploymentName = process.env.DEPLOYMENT_NAME;
     const deploymentUrl = process.env.DEPLOYMENT_URL;
-    expect(deploymentUrl).toBeTruthy(); // Ensure the DEPLOYMENT_URL is set
+    const testUrl = `https://${deploymentUrl}/hello-world`;
 
-    if (deploymentUrl) {
-      // Updated to visit /hello-world path
-      const testUrl = `https://${deploymentUrl}/hello-world`;
-
-      
-      console.log(`Navigating to URL: ${testUrl}`);
-      await page.goto(testUrl, { waitUntil: 'domcontentloaded' });
+    await page.goto(testUrl);
+    const h1Content = await page.$eval('h1', element => element.innerHTML);
+    const h2Content = await page.$eval('h2', element => element.innerHTML);
   
-    } else {
-      throw new Error('Deployment URL is undefined');
-    }
-    const bodyText = await page.evaluate(() => document.body.innerText);
-    expect(bodyText).toContain('Hello World From Akamai EdgeWorkers');
- 
-
+    expect(h1Content).toBe(`Hello World From Akamai EdgeWorkers:`);
+    expect(h2Content).toBe(`Deployment: ${deploymentName}`);
   });
+
 });

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,10 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "inject-hello-world": "node build-scripts/hello-world-injector.js",
+    "ew-bundle-versioner": "node build-scripts/ew-bundle-versioner.js",
+    "build": "npm run inject-hello-world && npm run ew-bundle-versioner"
   },
   "keywords": [],
   "author": "",

--- a/terraform/default_rules.tf
+++ b/terraform/default_rules.tf
@@ -27,7 +27,7 @@ data "akamai_property_rules_builder" "my-property_rule_default" {
       data.akamai_property_rules_builder.my-property_rule_augment_insights.json,
       data.akamai_property_rules_builder.my-property_rule_accelerate_delivery.json,
       data.akamai_property_rules_builder.my-property_rule_offload_origin.json,
-      data.akamai_property_rules_builder.my-property_rule_ew_test_example.json,
+      data.akamai_property_rules_builder.ew-routing-rule.json,
       data.akamai_property_rules_builder.my-property_rule_strengthen_security.json,
       data.akamai_property_rules_builder.my-property_rule_increase_availability.json,
       data.akamai_property_rules_builder.my-property_rule_minimize_payload.json,
@@ -126,31 +126,6 @@ data "akamai_property_rules_builder" "my-property_rule_offload_origin" {
       data.akamai_property_rules_builder.my-property_rule_graph_ql.json,
       data.akamai_property_rules_builder.my-property_rule_uncacheable_objects.json,
     ]
-  }
-}
-
-data "akamai_property_rules_builder" "my-property_rule_ew_test_example" {
-  rules_v2024_02_12 {
-    name                  = "EW_TEST_EXAMPLE"
-    criteria_must_satisfy = "all"
-    criterion {
-      path {
-        match_case_sensitive = false
-        match_operator       = "MATCHES_ONE_OF"
-        normalize            = false
-        values               = ["/hello-world", ]
-      }
-    }
-    behavior {
-      edge_worker {
-        create_edge_worker  = ""
-        edge_worker_id      = "85795"
-        enabled             = true
-        m_pulse             = false
-        m_pulse_information = ""
-        resource_tier       = ""
-      }
-    }
   }
 }
 

--- a/terraform/ew_rules.tf
+++ b/terraform/ew_rules.tf
@@ -9,7 +9,7 @@ data "akamai_property_rules_builder" "ew-routing-rule" {
         match_case_sensitive = false
         match_operator       = "MATCHES_ONE_OF"
         normalize            = false
-        values               = [format("/%s", var.deployment_name)]
+        values               = ["/hello-world", ]
       }
     }
     behavior {
@@ -24,4 +24,3 @@ data "akamai_property_rules_builder" "ew-routing-rule" {
     }
   }
 }
-


### PR DESCRIPTION
There was a bug where EW updates weren't deploying.  I realized that the EW was hard-coded to    ` edge_worker_id      = "85795"`

- [x] The first commit here fixes that.  

- [x] To prevent this from happening i am going to update the build for the EW to take the env variable for the deployment name and add that to the display in the EW bundle to prove that its updating.  We can update jest to verify that behavior.

- [x] need to automate the node build to increment the bundle version otherwise akamai's API's will fail validation.